### PR TITLE
Add protobuf version to match tensorflow

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -10,4 +10,5 @@ dependencies:
   - h5py==2.10.0
   - keras==2.3.1
   - tensorflow==2.0.0
+  - protobuf==3.20.*
 name: mlflow-env


### PR DESCRIPTION
Latest environments seem to have a version of protobuf pre-installed which is incompatible with tensorflow==2.0.0
Hence, the downgrade to protobuf==3.20.* is necessary